### PR TITLE
Added base API for model and plugins

### DIFF
--- a/api/graph-explorer-api/model/edge.py
+++ b/api/graph-explorer-api/model/edge.py
@@ -1,0 +1,15 @@
+from dataclasses import dataclass
+from .node import Node
+
+@dataclass
+class Edge:
+    """
+    Represents an edge (connection) between two nodes in a graph.
+
+    Attributes:
+        from_node (Node): The starting node of the edge.
+        to_node (Node): The ending node of the edge.
+    """
+    
+    from_node: Node
+    to_node: Node

--- a/api/graph-explorer-api/model/graph.py
+++ b/api/graph-explorer-api/model/graph.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+from dataclasses import dataclass, field
+from typing import List
+from .node import Node
+from .edge import Edge
+
+@dataclass
+class Graph:
+    """
+    Represents a graph structure consisting of nodes and edges.
+
+    Attributes:
+        nodes (List[Node]): List of nodes in the graph.
+        edges (List[Edge]): List of edges in the graph.
+        directed (bool): True if the graph is directed.
+    """
+    
+    nodes: List[Node] = field(default_factory=list)
+    edges: List[Edge] = field(default_factory=list)
+    directed: bool = False
+
+    def __post_init__(self):
+        node_ids = {node.id for node in self.nodes}
+
+        for edge in self.edges:
+            if edge.from_node.id not in node_ids or edge.to_node.id not in node_ids:
+                raise ValueError(f"Edge {edge} connects nodes not in the graph!")

--- a/api/graph-explorer-api/model/node.py
+++ b/api/graph-explorer-api/model/node.py
@@ -1,0 +1,16 @@
+from dataclasses import dataclass, field
+
+@dataclass
+class Node:
+    """
+    Represents a single node (vertex) in a graph.
+
+    Attributes:
+        id (int): Unique identifier for the node.
+        data (dict): Optional dictionary holding additional information about the node.
+                     Defaults to an empty dictionary if not provided. Can store
+                     arbitrary attributes like labels, names, or other metadata.
+    """
+    
+    id: int
+    data: dict = field(default_factory=dict)

--- a/api/graph-explorer-api/plugins/base.py
+++ b/api/graph-explorer-api/plugins/base.py
@@ -1,0 +1,24 @@
+from abc import ABC, abstractmethod
+
+class Plugin(ABC):
+    """Base class for all plugins."""
+
+    @abstractmethod
+    def name(self) -> str:
+        """
+        Returns the name of the plugin.
+        
+        :return: The name of the plugin.
+        :rtype: str
+        """
+        pass
+
+    @abstractmethod
+    def identifier(self) -> str:
+        """
+        Retrieves a unique identifier for the plugin.
+
+        :return: The unique identifier of the plugin.
+        :rtype: str
+        """
+        pass

--- a/api/graph-explorer-api/plugins/data_source_plugin.py
+++ b/api/graph-explorer-api/plugins/data_source_plugin.py
@@ -1,0 +1,20 @@
+from abc import abstractmethod
+from .base import Plugin
+from model.graph import Graph
+
+class DataSourcePlugin(Plugin):
+    """
+    An abstraction representing a plugin for loading data from a specific data source.
+    """
+
+    @abstractmethod
+    def load(self, **kwargs) -> Graph:
+        """
+        Loads data from the data source and returns it as a `Graph` object.
+
+        :param kwargs: Arbitrary keyword arguments for customization or filtering of the data loading process.
+        :type kwargs: dict
+        :return: `Graph` object loaded from the data source.
+        :rtype: Graph
+        """
+        pass

--- a/api/graph-explorer-api/plugins/visualizer_plugin.py
+++ b/api/graph-explorer-api/plugins/visualizer_plugin.py
@@ -1,0 +1,24 @@
+from abc import abstractmethod
+from .base import Plugin
+from model.graph import Graph
+
+class VisualizerPlugin(Plugin):
+    """
+    An abstraction representing a plugin for visualizing Graph objects.
+
+    This class defines the interface that all visualizer plugins must implement.
+    """
+
+    @abstractmethod
+    def visualize(self, graph: Graph, **kwargs) -> None:
+        """
+        Visualizes the given Graph object.
+
+        :param graph: The Graph object to be visualized.
+        :type graph: `Graph`
+        :param kwargs: Arbitrary keyword arguments for customization of the visualization,
+                       such as colors, layout options, labels, or rendering styles.
+        :type kwargs: dict
+        :return: None
+        """
+        pass


### PR DESCRIPTION
🆕 I have added the basic classes for the models (`Node`, `Edge`, `Graph`) and abstract classes for the plugins (`Plugin`, `DataSourcePlugin`, `VisualizerPlugin`).

Based on the project specification, I concluded that the API should look roughly like this. I also referred to the [example](https://github.com/DanijelRadakovic/sok/tree/master/11-app/api/shop/api) provided by the assistant – the structure is very similar. The main difference is that I separated the plugin classes into different files because we have more plugin types than in the assistant’s example.

One note: I’m not entirely sure whether we should concretize the model based on the examples from the specification, or if it’s fine to leave it as a dict.

🤝 Please take a look and let me know if you think anything should be changed. Thank you in advance for your feedback!