### PR TITLE
Simple visualizer plugin

### DIFF
--- a/simple_visualizer/pyproject.toml
+++ b/simple_visualizer/pyproject.toml
@@ -1,7 +1,20 @@
 [project]
-name = "simple_visualzier"
+name = "simple_visualizer"
 version = "0.1"
 description = "Simple visualizer plugin"
 dependencies = [
     "graph_explorer_api==0.1",
 ]
+
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+packages = ["simple_visualizer"]
+
+[project.entry-points."graph_explorer.visualizers"]
+simple_visualizer = "simple_visualizer.simple_visualizer:SimpleVisualizerPlugin"
+
+[tool.setuptools.data-files]
+templates = ["simple_visualizer/templates/*"]

--- a/simple_visualizer/simple_visualizer/simple_visualizer.py
+++ b/simple_visualizer/simple_visualizer/simple_visualizer.py
@@ -1,0 +1,40 @@
+import os
+from graph_explorer_api.model.graph import Graph
+from jinja2 import FileSystemLoader, Environment
+from graph_explorer_api.plugins.visualizer_plugin import VisualizerPlugin 
+
+class SimpleVisualizerPlugin(VisualizerPlugin):
+
+  def name(self) -> str:
+    return "Simple Visualizer"
+  
+  def identifier(self) -> str:
+    return "simple_visualizer"
+
+  def visualize(self, graph: Graph, **kwargs) -> str:
+    p = os.path.dirname(__file__)
+    path = os.path.join(p, "templates")
+    env = Environment(loader=FileSystemLoader(searchpath=path))
+    template = env.get_template("simple_visualizer.html")
+
+    nodes_js = [ 
+      {"id": str(n.id)}
+      for n in graph.nodes
+    ]
+
+    edges_js = [
+      {
+        "source": str(e.from_node.id),
+        "target": str(e.to_node.id),
+        "directed": graph.directed
+      }
+      for e in graph.edges
+    ]
+
+    context = {
+      "nodes": nodes_js,
+      "edges": edges_js,
+      "directed": graph.directed
+    }
+
+    return template.render(context)

--- a/simple_visualizer/simple_visualizer/templates/simple_visualizer.html
+++ b/simple_visualizer/simple_visualizer/templates/simple_visualizer.html
@@ -1,0 +1,116 @@
+<style>
+    #graph-container {
+        width: 80%;
+        height: 70vh;
+        border: 1px solid #ccc;
+        margin: auto;
+        background: #f9f9f9;
+    }
+
+    .node circle {
+        fill: #469cc7;
+        stroke: #1a73c7;
+        stroke-width: 1.5px;
+    }
+
+    .link {
+        stroke: #999;
+        stroke-opacity: 0.6;
+        stroke-width: 2px;
+    }
+
+    marker#arrowhead {
+        fill: #999;
+    }
+
+    .node text {
+        font-size: 12px;
+        pointer-events: none;
+        fill: white;
+        font-weight: bold;
+    }
+</style>
+
+<script id="nodes-data" type="application/json">
+    {{ nodes | tojson }}
+</script>
+
+<script id="edges-data" type="application/json">
+    {{ edges | tojson }}
+</script>
+
+<div id="graph-container"></div>
+
+<script type="text/javascript" src="https://d3js.org/d3.v3.js"></script>
+<script type="text/javascript">
+function render() {
+    const graphNodes = JSON.parse(document.getElementById("nodes-data").textContent);
+    const graphLinks = JSON.parse(document.getElementById("edges-data").textContent);
+
+    const nodeById = {};
+    graphNodes.forEach(n => nodeById[n.id] = n);
+    graphLinks.forEach(l => {
+        l.source = nodeById[l.source];
+        l.target = nodeById[l.target];
+    });
+
+    const width = document.querySelector("#graph-container").clientWidth;
+    const height = document.querySelector("#graph-container").clientHeight;
+
+    const svg = d3.select("#graph-container").append("svg")
+        .attr("width", width)
+        .attr("height", height);
+
+    // Arrow marker
+    svg.append("defs").append("marker")
+        .attr("id", "arrowhead")
+        .attr("viewBox", "0 -5 10 10")
+        .attr("refX", 15)
+        .attr("refY", 0)
+        .attr("markerWidth", 10)
+        .attr("markerHeight", 10)
+        .attr("orient", "auto")
+        .append("path")
+        .attr("d", "M0,-5L10,0L0,5");
+
+    const force = d3.layout.force()
+        .nodes(graphNodes)
+        .links(graphLinks)
+        .size([width, height])
+        .linkDistance(150)
+        .charge(-400)
+        .on("tick", ticked)
+        .start();
+
+    const link = svg.selectAll(".link")
+        .data(graphLinks)
+        .enter().append("line")
+        .attr("class", "link")
+        .attr("marker-end", d => d.directed ? "url(#arrowhead)" : "");
+
+    const node = svg.selectAll(".node")
+        .data(graphNodes)
+        .enter().append("g")
+        .attr("class", "node")
+        .call(force.drag);
+
+    node.append("circle")
+        .attr("r", 20);
+
+    node.append("text")
+        .attr("text-anchor", "middle")
+        .attr("dy", 4)
+        .text(d => d.id);
+
+    function ticked() {
+        link.attr("x1", d => d.source.x)
+            .attr("y1", d => d.source.y)
+            .attr("x2", d => d.directed ? d.target.x : d.target.x)
+            .attr("y2", d => d.directed ? d.target.y : d.target.y);
+
+        node.attr("transform", d => `translate(${d.x},${d.y})`);
+    }
+}
+
+render();
+</script>


### PR DESCRIPTION
The Simple Visualizer plugin has been implemented.
The main difference compared to the Block Visualizer plugin is that it only displays node IDs, rather than a full list of attributes.