### PR TITLE
#23: Bugfix - JSON Datetime UI conversion

### DIFF
--- a/block_visualizer/block_visualizer/block_visualizer.py
+++ b/block_visualizer/block_visualizer/block_visualizer.py
@@ -1,4 +1,6 @@
 import os
+from datetime import date, datetime
+
 from jinja2 import FileSystemLoader, Environment
 from graph_explorer_api.plugins.visualizer_plugin import VisualizerPlugin 
 from graph_explorer_api.model.graph import Graph
@@ -11,6 +13,13 @@ class BlockVisualizerPlugin(VisualizerPlugin):
   def identifier(self) -> str:
     return "block_visualizer"
 
+  def safe_value(self, value):
+      if isinstance(value, datetime):
+          return value.strftime("%d.%m.%Y. %H:%M")  # "24.08.2025. 21:15" (date and time)
+      elif isinstance(value, date):
+          return value.strftime("%d.%m.%Y.")  # "24.08.2025." (only date)
+      return str(value)
+
   def visualize(self, graph: Graph, **kwargs) -> str:
     p = os.path.dirname(__file__)
     path = os.path.join(p, "templates")
@@ -22,7 +31,7 @@ class BlockVisualizerPlugin(VisualizerPlugin):
             "id": str(n.id),
             "name": str(n.data.get('name', n.id)) if n.data.get('name', n.id) is not None else str(n.id),
             "attributes": [
-                {"name": key, "value": value}
+                {"name": key, "value": self.safe_value(value)}
                 for key, value in n.data.items()
                 if key is not None and value is not None and key != 'name'
             ]

--- a/data_source_json/data_source_json/main.py
+++ b/data_source_json/data_source_json/main.py
@@ -2,5 +2,5 @@ from data_source_json.data_source_parser import DataSourceJSONParser
 
 if __name__ == "__main__":
     parser = DataSourceJSONParser()
-    graph = parser.load(path="test_files/test.json", )
+    graph = parser.load(path="test_files/test.json")
     print(graph)

--- a/data_source_json/data_source_json/parser.py
+++ b/data_source_json/data_source_json/parser.py
@@ -14,7 +14,7 @@ class JSONParser:
 
     def parse(self, data: str, graph_type: JSONGraphType) -> Graph:
         self.__reset()  # so different instances won't use the same values
-        self.__graph.directed = graph_type == JSONGraphType.DIRECTED.value
+        self.__graph.directed = graph_type == JSONGraphType.DIRECTED
 
         json_data = json.loads(data)
         self.__build_graph(json_data, parent_id=None)
@@ -56,7 +56,7 @@ class JSONParser:
             self.__add_edge(self.__nodes[parent_id], current_node)
 
         if "parent" in json_data:
-            self.__edges_to_resolve.append((root_node_id, json_data["parent"]))
+            self.__edges_to_resolve.append((str(root_node_id), str(json_data["parent"])))
 
         # go through children
         for _, val in json_data.items():

--- a/data_source_json/data_source_json/test_files/test.json
+++ b/data_source_json/data_source_json/test_files/test.json
@@ -4,19 +4,16 @@
       "@id": "1",
       "name": "Parent Node",
       "weight": 3.5,
-      "created": "2025-08-24",
+      "created": "2025-08-24 12:52",
       "children": [
         {
           "@id": "2",
           "name": "First Child",
-          "parent": 1,
-          "value": 42,
-          "children": []
+          "value": 42
         },
         {
           "@id": "3",
           "name": "Second Child",
-          "parent": 1,
           "value": 17.2,
           "children": [
             {


### PR DESCRIPTION
Good evening, _colleague_! 🌹😊  

Here is the summary of what I did in this PR.

---

### 🟥 BUGFIX:

> Data source JSON plugin
- JSON parser now `properly handles` both graph types (**directed** / **undirected**), ✔️ 
- IDs of nodes appended to the list for resolving `bidirectional` relationships are now of type **string** ✔️ (the bug occurred when one node ID was an _int_ while the other was a _str_).

> Block Visualizer
- added `safe conversion` method for `datetime` in Block Visualizer (the bug in UI occurred because datetime from JSON data wasn't converted properly - it works fine in the parser, but error happens during rendering (_"Object of type datetime is not JSON serializable"_))

---

That's it for now.
Please review my code and feel free to comment on anything you think needs to be changed, added or deleted.

> Thank you for your time. 🌞
> </> Best regards and happy coding! </>
> 
> ~ Tamara 🦔