### PR TITLE
Feature tree view

### DIFF
--- a/data_source_xml/data_source_xml/test_files/simple_longer_test.xml
+++ b/data_source_xml/data_source_xml/test_files/simple_longer_test.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<library>
+    <info>
+        <name>Central City Library</name>
+        <address>Main Street 123, Central City</address>
+        <established>1985</established>
+    </info>
+
+    <books>
+        <book id="B001">
+            <title>The Fellowship of the Ring</title>
+            <author id="A001">J.R.R. Tolkien</author>
+            <genre>Fantasy</genre>
+            <published>1954</published>
+            <available>true</available>
+        </book>
+        <book id="B002">
+            <title>The Two Towers</title>
+            <author id="A001">J.R.R. Tolkien</author>
+            <genre>Fantasy</genre>
+            <published>1954</published>
+            <available>false</available>
+        </book>
+        <book id="B003">
+            <title>1984</title>
+            <author id="A002">George Orwell</author>
+            <genre>Dystopian</genre>
+            <published>1949</published>
+            <available>true</available>
+        </book>
+        <book id="B004">
+            <title>Brave New World</title>
+            <author id="A003">Aldous Huxley</author>
+            <genre>Dystopian</genre>
+            <published>1932</published>
+            <available>true</available>
+        </book>
+    </books>
+
+    <authors>
+        <author id="A001">
+            <name>J.R.R. Tolkien</name>
+            <birth>1892</birth>
+            <death>1973</death>
+            <nationality>British</nationality>
+        </author>
+        <author id="A002">
+            <name>George Orwell</name>
+            <birth>1903</birth>
+            <death>1950</death>
+            <nationality>British</nationality>
+        </author>
+        <author id="A003">
+            <name>Aldous Huxley</name>
+            <birth>1894</birth>
+            <death>1963</death>
+            <nationality>British</nationality>
+        </author>
+    </authors>
+
+    <members>
+        <member id="M001">
+            <name>Alice Johnson</name>
+            <joined>2021-05-14</joined>
+            <borrowed>
+                <bookRef>B002</bookRef>
+            </borrowed>
+        </member>
+        <member id="M002">
+            <name>Bob Smith</name>
+            <joined>2020-11-02</joined>
+            <borrowed>
+                <bookRef>B001</bookRef>
+                <bookRef>B003</bookRef>
+            </borrowed>
+        </member>
+        <member id="M003">
+            <name>Clara Lee</name>
+            <joined>2022-01-22</joined>
+            <borrowed/>
+        </member>
+    </members>
+</library>

--- a/data_source_xml/data_source_xml/test_files/test.xml
+++ b/data_source_xml/data_source_xml/test_files/test.xml
@@ -1,6 +1,9 @@
 <node>
     <child_node>
         <leaf>Something</leaf>
+        <friend>
+            <child_node reference="/node/child_node[2]"/>
+        </friend>
     </child_node>
     <child_node>
         <leaf>Something else</leaf>

--- a/graph_explorer/graph_explorer/apps.py
+++ b/graph_explorer/graph_explorer/apps.py
@@ -1,4 +1,5 @@
 from django.apps import AppConfig
+from use_cases.graph_tree_view import TreeViewService
 from use_cases.plugin_recognition import PluginService
 from use_cases.const import VISUALIZER_GROUP
 from use_cases.const import DATA_SOURCE_GROUP
@@ -7,6 +8,7 @@ class GraphExplorerConfig(AppConfig):
   default_auto_field = 'django.db.models.BigAutoField'
   name = 'graph_explorer'
   plugin_service = PluginService()
+  tree_view_service = TreeViewService()
 
   def ready(self):
     # On aplication start load all plugins

--- a/graph_explorer/graph_explorer/static/style.css
+++ b/graph_explorer/graph_explorer/static/style.css
@@ -49,6 +49,11 @@ body, html {
     font-weight: bold;
 }
 
+.left p {
+    font-weight: bold;
+    font-size: 20px;
+}
+
 .center {
     grid-area: main;
     padding: 10px;

--- a/graph_explorer/graph_explorer/templates/base.html
+++ b/graph_explorer/graph_explorer/templates/base.html
@@ -22,6 +22,10 @@
                 <a href="{% url 'index' %}">Home</a>
             </li>
         </ul>
+        <p>Tree layout</p>
+        <div class="tree-container">
+            {{ tree_view }}
+        </div>
             {% block links %}{% endblock %}
     </div>
     <div class="center">

--- a/graph_explorer/graph_explorer/templates/tree_view.html
+++ b/graph_explorer/graph_explorer/templates/tree_view.html
@@ -17,7 +17,7 @@
     position: relative;
 }
 .tree li span {
-    display: block;  /* make each property go on its own line */
+    display: block;
     padding: 2px 6px;
     border-radius: 4px;
     transition: background-color 0.2s;
@@ -51,31 +51,60 @@
 .node-attr {
     font-size: 12px;
     color: #777;
-    margin-left: 20px;  /* indent id under the name */
+    margin-left: 20px;
 }
 </style>
 
 <script>
 document.addEventListener("DOMContentLoaded", function() {
-    // Pass tree_data from Django safely
     const treeData = JSON.parse('{{ tree_view|escapejs }}');
 
     const nodeIndex = {};
+    function isRicher(newNode, existingNode) {
+        const newHasChildren = !!(newNode && newNode.children && newNode.children.length);
+        const existingHasChildren = !!(existingNode && existingNode.children && existingNode.children.length);
+        if (newHasChildren && !existingHasChildren) return true;
+        if (!newHasChildren && existingHasChildren) return false;
+        const newKeys = newNode ? Object.keys(newNode).length : 0;
+        const existingKeys = existingNode ? Object.keys(existingNode).length : 0;
+        return newKeys > existingKeys;
+    }
     function indexNodes(node) {
-        if (!node.id) return;
-        nodeIndex[node.id] = node;
+        if (!node || !node.id) {
+            if (node && node.children) node.children.forEach(indexNodes);
+            return;
+        }
+        const existing = nodeIndex[node.id];
+        if (!existing || isRicher(node, existing)) {
+            nodeIndex[node.id] = node;
+        }
         if (node.children) {
             node.children.forEach(indexNodes);
         }
     }
     indexNodes(treeData);
 
+    function hasExpandableChildren(node) {
+        const hasOwnChildren = !!(node.children && node.children.length);
+        if (hasOwnChildren) return true;
+        if (node.id) {
+            const full = nodeIndex[node.id];
+            if (full && full.children && full.children.length) return true;
+        }
+        return false;
+    }
+
     function buildTree(node, parentElement) {
         const li = document.createElement("li");
+        if (node.id) li.dataset.nodeId = node.id;
 
         // name
         const nameSpan = document.createElement("span");
         nameSpan.textContent = node.name;
+
+        if (hasExpandableChildren(node)) {
+            nameSpan.classList.add("caret");
+        }
 
         li.appendChild(nameSpan);
 
@@ -89,7 +118,6 @@ document.addEventListener("DOMContentLoaded", function() {
         }
 
         if (node.children && node.children.length > 0) {
-            nameSpan.classList.add("caret");
             const ul = document.createElement("ul");
             ul.classList.add("nested");
             node.children.forEach(child => buildTree(child, ul));
@@ -102,14 +130,31 @@ document.addEventListener("DOMContentLoaded", function() {
     const rootElement = document.getElementById("tree-root");
     buildTree(treeData, rootElement);
 
-    // Toggle expand/collapse
     rootElement.addEventListener("click", function(event) {
-        if (event.target.classList.contains("caret")) {
-            const nested = event.target.parentElement.querySelector(".nested");
-            if (nested) {
-                nested.classList.toggle("active");
-                event.target.classList.toggle("caret-down");
+        if (!event.target.classList.contains("caret")) return;
+
+        const li = event.target.closest("li");
+        if (!li) return;
+
+        let nested = null;
+        try {
+            nested = li.querySelector(":scope > ul.nested");
+        } catch (e) {
+            nested = li.querySelector("ul.nested");
+        }
+        if (!nested) {
+            const nodeId = li.dataset.nodeId;
+            if (nodeId && nodeIndex[nodeId] && nodeIndex[nodeId].children && nodeIndex[nodeId].children.length) {
+                nested = document.createElement("ul");
+                nested.classList.add("nested");
+                nodeIndex[nodeId].children.forEach(child => buildTree(child, nested));
+                li.appendChild(nested);
             }
+        }
+
+        if (nested) {
+            nested.classList.toggle("active");
+            event.target.classList.toggle("caret-down");
         }
     });
 });

--- a/graph_explorer/graph_explorer/templates/tree_view.html
+++ b/graph_explorer/graph_explorer/templates/tree_view.html
@@ -1,0 +1,117 @@
+{% block tree_block %}
+<div class="tree-container">
+    <ul class="tree" id="tree-root"></ul>
+</div>
+
+<style>
+.tree {
+    list-style-type: none;
+    margin: 0;
+    padding-left: 0;
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    font-size: 14px;
+}
+.tree li {
+    line-height: 1.8em;
+    padding-left: 15px;
+    position: relative;
+}
+.tree li span {
+    display: block;  /* make each property go on its own line */
+    padding: 2px 6px;
+    border-radius: 4px;
+    transition: background-color 0.2s;
+}
+.tree li span:hover {
+    background-color: #cecece;
+}
+.caret {
+    cursor: pointer;
+    user-select: none;
+    font-weight: bold;
+}
+.caret::before {
+    content: "►";
+    color: #555;
+    display: inline-block;
+    margin-right: 6px;
+    transition: transform 0.2s;
+}
+.caret-down::before {
+    transform: rotate(90deg);
+}
+.nested {
+    display: none;
+    list-style-type: none;
+    padding-left: 15px;
+}
+.active {
+    display: block;
+}
+.node-attr {
+    font-size: 12px;
+    color: #777;
+    margin-left: 20px;  /* indent id under the name */
+}
+</style>
+
+<script>
+document.addEventListener("DOMContentLoaded", function() {
+    // Pass tree_data from Django safely
+    const treeData = JSON.parse('{{ tree_view|escapejs }}');
+
+    const nodeIndex = {};
+    function indexNodes(node) {
+        if (!node.id) return;
+        nodeIndex[node.id] = node;
+        if (node.children) {
+            node.children.forEach(indexNodes);
+        }
+    }
+    indexNodes(treeData);
+
+    function buildTree(node, parentElement) {
+        const li = document.createElement("li");
+
+        // name
+        const nameSpan = document.createElement("span");
+        nameSpan.textContent = node.name;
+
+        li.appendChild(nameSpan);
+
+        for (key in node) {
+            if (key !== "name" && key !== "children") {
+                const attrSpan = document.createElement("span");
+                attrSpan.textContent = key + ": " + node[key];
+                attrSpan.classList.add("node-attr");
+                li.appendChild(attrSpan);
+            }
+        }
+
+        if (node.children && node.children.length > 0) {
+            nameSpan.classList.add("caret");
+            const ul = document.createElement("ul");
+            ul.classList.add("nested");
+            node.children.forEach(child => buildTree(child, ul));
+            li.appendChild(ul);
+        }
+
+        parentElement.appendChild(li);
+    }
+
+    const rootElement = document.getElementById("tree-root");
+    buildTree(treeData, rootElement);
+
+    // Toggle expand/collapse
+    rootElement.addEventListener("click", function(event) {
+        if (event.target.classList.contains("caret")) {
+            const nested = event.target.parentElement.querySelector(".nested");
+            if (nested) {
+                nested.classList.toggle("active");
+                event.target.classList.toggle("caret-down");
+            }
+        }
+    });
+});
+</script>
+{% endblock %}

--- a/graph_explorer/graph_explorer/views.py
+++ b/graph_explorer/graph_explorer/views.py
@@ -1,9 +1,9 @@
 from django.core.files.storage import FileSystemStorage
 from django.shortcuts import render
 from django.apps import apps
+
 from use_cases.const import VISUALIZER_GROUP
 from use_cases.const import DATA_SOURCE_GROUP
-
 from graph_explorer_api.model.graph import Graph
 
 def index(request):
@@ -29,10 +29,14 @@ def index(request):
     graph = selected_data_source_plugin.load(path=file_path) if file_path else Graph()
     graph_html = selected_visualizer_plugin.visualize(graph) if selected_visualizer_plugin else "No visualizer selected 🚫"
 
+    tree_view_service = apps.get_app_config('graph_explorer').tree_view_service
+    tree_view = tree_view_service.generate_template(graph)
+
     return render(request, "index.html", {
         "visualizer_plugins": visualizer_plugins,
         "data_source_plugins": data_source_plugins,
         "graph_html": graph_html,
         "selected_visualizer_plugin": selected_visualizer_plugin.identifier() if selected_visualizer_plugin else None,
-        "selected_data_source_plugin": selected_data_source_plugin.identifier() if selected_data_source_plugin else None
+        "selected_data_source_plugin": selected_data_source_plugin.identifier() if selected_data_source_plugin else None,
+        "tree_view": tree_view
     })

--- a/platform/src/use_cases/graph_tree_view.py
+++ b/platform/src/use_cases/graph_tree_view.py
@@ -1,0 +1,61 @@
+import json
+
+from django.template.loader import get_template
+from graph_explorer_api.model.graph import Graph
+from graph_explorer_api.model.node import Node
+
+class TreeNode:
+    def __init__(self, node: Node, parent: Node = None):
+        self.node = node
+        self.children = []
+        self.parent = parent
+
+class TreeViewService(object):
+    def __init__(self):
+        self.__tree_root = None
+        self.__graph = None
+        self.__visited = set()
+
+    def generate_template(self, graph: Graph) -> str:
+        if graph is not None and len(graph.nodes) > 0:
+            self.__tree_root = TreeNode(graph.nodes[0])
+            self.__graph = graph
+            self.__generate_tree(self.__tree_root)
+            self.__visited = set()
+
+        json_data = self.__generate_tree_json(self.__tree_root)
+        template_path = "tree_view.html"
+        template = get_template(template_path)
+        json_data_str = json.dumps(json_data)
+
+        return template.render({'tree_view': json_data_str})
+
+    def __generate_tree(self, current_node: TreeNode):
+        if current_node is None:
+            return None
+
+        self.__visited.add(current_node.node.id)
+        for edge in self.__graph.edges:
+            if edge.from_node.id == current_node.node.id:
+                child_node = TreeNode(edge.to_node, current_node)
+                current_node.children.append(child_node)
+                if child_node.node.id not in self.__visited:
+                    self.__generate_tree(child_node)
+
+            elif not self.__graph.directed and edge.to_node.id == current_node.node.id:
+                child_node = TreeNode(edge.from_node, current_node)
+                current_node.children.append(child_node)
+                if child_node.node.id not in self.__visited:
+                    self.__generate_tree(child_node)
+
+    def __generate_tree_json(self, tree_node: TreeNode) -> dict:
+        if tree_node is None:
+            return {}
+
+        return {
+            "id": tree_node.node.id,
+            **tree_node.node.data,
+            "children" : [
+                self.__generate_tree_json(child) for child in tree_node.children if child is not None
+            ]
+        }


### PR DESCRIPTION
Ticket: #4 

In short, Tree View is added with this PR. Honestly, it was much more complicated than I expected. There is a new service in our platform called TreeViewService. It takes in the graph and combines it with the tree_view.html template for the rendering of the Tree View (it returns string that is rendered combined HTML of that). That rendered HTML is then added in the base.html (that our index.html extends) through our views.py index method and Django's {{}}.

TreeViewService creates a tree starting from the first node in the graph. For every reference it finds, it just creates a node copy, without its children. But then in the template (tree_view.html), those empty children are replaced with real children with a bit of JS code. The code there is a lot more complicated, but it works just fine.