### PR TITLE
Bugfix data source xml loading graphs over current

### DIFF
--- a/data_source_xml/data_source_xml/parser.py
+++ b/data_source_xml/data_source_xml/parser.py
@@ -108,3 +108,4 @@ class XmlParser:
         self.__references = []
         self.__xml_elements_to_graph_nodes = {}
         self.__graph = Graph()
+        self.__node_count = 0

--- a/data_source_xml/data_source_xml/parser.py
+++ b/data_source_xml/data_source_xml/parser.py
@@ -24,8 +24,9 @@ class XmlParser:
 
         self.__resolve_references()
 
+        ret_graph = self.__graph
         self.__reset()
-        return self.__graph
+        return ret_graph
 
     def __parse_xml_root(self, xml: str) -> etree._Element:
         parser = etree.XMLParser(remove_blank_text=True)
@@ -106,3 +107,4 @@ class XmlParser:
         self.__id = 0
         self.__references = []
         self.__xml_elements_to_graph_nodes = {}
+        self.__graph = Graph()


### PR DESCRIPTION
Ticket: #27 

You were right yesterday! Here is the quick fix for the graphs loading over each other when the data source plugin chosen is XML