### PR TITLE
#31: Added method for making tree view empty for workspaces with no graphs

### DIFF
--- a/platform/src/use_cases/graph_tree_view.py
+++ b/platform/src/use_cases/graph_tree_view.py
@@ -59,3 +59,13 @@ class TreeViewService(object):
                 self.__generate_tree_json(child) for child in tree_node.children if child is not None
             ]
         }
+
+    def empty_tree(self) -> str:
+        self.__tree_root = None
+        self.__graph = None
+        self.__visited = set()
+
+        template_path = "tree_view.html"
+        template = get_template(template_path)
+        json_data_str = json.dumps({})
+        return template.render({'tree_view': json_data_str})

--- a/platform/src/use_cases/workspace/workspace_service.py
+++ b/platform/src/use_cases/workspace/workspace_service.py
@@ -58,6 +58,7 @@ def get_active_workspace(session, ws_id, file_path=None, datasource=None, visual
 
     ws_dict = workspaces[ws_id]
     ws = Workspace(**ws_dict)
+    ws.tree_view = tree_view_service.empty_tree()
     if file_path:
         ws.file_path = file_path
     if datasource:
@@ -83,6 +84,7 @@ def create_workspace(session, file_path=None, datasource=None, visualizer=None, 
         data_source_identifier=datasource,
         visualizer_identifier=visualizer,
     )
+    ws.tree_view = tree_view_service.empty_tree()
     if plugin_service and tree_view_service:
         ws.load_graph(plugin_service, tree_view_service)
     _add_workspace(session, ws)


### PR DESCRIPTION
Ticket: #31 

Very small bugfix, explained in the issue