### PR TITLE
#33: Bugfix xml plugin graphs not directed

### DIFF
--- a/config/data_source_xml_parser_config.json
+++ b/config/data_source_xml_parser_config.json
@@ -1,4 +1,5 @@
 {
   "loader_type": "file",
-  "reference_attribute": "reference"
+  "reference_attribute": "reference",
+  "graph_type": "undirected"
 }

--- a/data_source_xml/data_source_xml/configuration.py
+++ b/data_source_xml/data_source_xml/configuration.py
@@ -6,12 +6,17 @@ class XMLLoaderType(Enum):
     FILE = "file"
     LINK = "link"
 
+class GraphType(Enum):
+    DIRECTED = "directed"
+    UNDIRECTED = "undirected"
+
 class Configuration:
-    CONFIG_FILE_PATH = "config/data_source_xml_parser_config.json"
+    CONFIG_FILE_PATH = "../config/data_source_xml_parser_config.json"
 
     def __init__(self):
         self.__loader_type = XMLLoaderType.FILE
         self.__reference_attribute = "reference"
+        self.__graph_type = GraphType.DIRECTED
         self.__load_config()
 
     def get_loader_type(self) -> XMLLoaderType:
@@ -28,6 +33,13 @@ class Configuration:
         self.__reference_attribute = reference_attribute
         self.__save_config()
 
+    def get_graph_type(self) -> GraphType:
+        return self.__graph_type
+
+    def set_graph_type(self, graph_type: GraphType):
+        self.__graph_type = graph_type
+        self.__save_config()
+
     def __load_config(self):
         try:
             if not os.path.exists(self.CONFIG_FILE_PATH):
@@ -39,6 +51,9 @@ class Configuration:
                     config_data.get('loader_type', XMLLoaderType.FILE.value)
                 )
                 self.__reference_attribute = config_data.get('reference_attribute', 'reference')
+                self.__graph_type = GraphType(
+                    config_data.get('graph_type', GraphType.DIRECTED.value)
+                )
         except (json.JSONDecodeError, FileNotFoundError, ValueError):
             return
 
@@ -47,5 +62,6 @@ class Configuration:
         with open(self.CONFIG_FILE_PATH, 'w') as config_file:
             json.dump({
                 'loader_type': self.__loader_type.value,
-                'reference_attribute': self.__reference_attribute
+                'reference_attribute': self.__reference_attribute,
+                'graph_type': self.__graph_type.value
             }, config_file)

--- a/data_source_xml/data_source_xml/data_source_parser.py
+++ b/data_source_xml/data_source_xml/data_source_parser.py
@@ -1,7 +1,7 @@
 from graph_explorer_api.model.graph import Graph
 from graph_explorer_api.plugins.data_source_plugin import DataSourcePlugin
 from data_source_xml.loader import XmlLoader, XmlFileLoader, XmlLinkLoader
-from data_source_xml.configuration import Configuration, XMLLoaderType
+from data_source_xml.configuration import Configuration, XMLLoaderType, GraphType
 from data_source_xml.parser import XmlParser
 
 class DataSourceXmlParser(DataSourcePlugin):
@@ -13,7 +13,8 @@ class DataSourceXmlParser(DataSourcePlugin):
         self.__configure_plugin()
         xml = self.loader.load(kwargs.get("path"))
         reference_attribute = self.config.get_reference_attribute() if self.config else "reference"
-        return self.parser.parse_xml(xml, reference_attribute)
+        is_directed = self.config.get_graph_type() == GraphType.DIRECTED if self.config else True
+        return self.parser.parse_xml(xml, reference_attribute, is_directed)
 
     def __configure_plugin(self):
         loader_type = self.config.get_loader_type()

--- a/data_source_xml/data_source_xml/parser.py
+++ b/data_source_xml/data_source_xml/parser.py
@@ -12,8 +12,8 @@ class XmlParser:
     __graph: Graph = Graph()
     __root_xml_element: etree._Element = None
 
-    def parse_xml(self, xml: str, refrence_attribute: str) -> Graph:
-        self.__graph.directed = True
+    def parse_xml(self, xml: str, refrence_attribute: str, is_directed: bool) -> Graph:
+        self.__graph.directed = is_directed
         self.__reference_attribute = refrence_attribute
 
         self.__root_xml_element = self.__parse_xml_root(xml)


### PR DESCRIPTION
Ticket: #33 

This PR is all about adding option for graphs loaded with XML to be undirected. The configuration now looks like a duplication for JSON and XML, so this will be somehow united and cleaned in my next PR.