### PR TITLE
Feature all views sync

### DIFF
--- a/block_visualizer/block_visualizer/templates/block_visualizer.html
+++ b/block_visualizer/block_visualizer/templates/block_visualizer.html
@@ -130,6 +130,7 @@ function render() {
         const rectHeight = titleHeight + d.attributes.length * lineHeight + padding;
         const rectWidth = 140;
 
+        g.classed("node-" + d.id, true);
         // Rectangle
         g.append("rect")
             .attr("width", rectWidth)

--- a/graph_explorer/graph_explorer/templates/index.html
+++ b/graph_explorer/graph_explorer/templates/index.html
@@ -272,6 +272,29 @@ document.addEventListener("DOMContentLoaded", function() {
     nodes.on("mousedown", function() {
         d3.event.stopPropagation();
     });
+
+    (function ensureStyle() {
+      if (!document.getElementById("focused-style")) {
+        const style = document.createElement("style");
+        style.id = "focused-style";
+        style.textContent = `
+          .focused-node * {
+                stroke: #ff9800 !important;
+                stroke-width: 1.5px !important;
+            }
+
+            .node rect:hover {
+                cursor: pointer;
+            }
+        `;
+        document.head.appendChild(style);
+      }
+    })()
+
+    nodes.on("click", function() {
+        nodes.classed("focused-node", false);
+        d3.select(this).classed("focused-node", true);
+    });
 })
 </script>
 {% endblock %}

--- a/graph_explorer/graph_explorer/templates/index.html
+++ b/graph_explorer/graph_explorer/templates/index.html
@@ -278,6 +278,13 @@ document.addEventListener("DOMContentLoaded", function() {
         const style = document.createElement("style");
         style.id = "focused-style";
         style.textContent = `
+        .focused-node {
+                stroke: #ff9800 !important;
+                stroke-width: 1.5px !important;
+                border: 1px solid #ff9800 !important;
+                color: #ff9800 !important;
+            }
+
           .focused-node * {
                 stroke: #ff9800 !important;
                 stroke-width: 1.5px !important;
@@ -291,9 +298,11 @@ document.addEventListener("DOMContentLoaded", function() {
       }
     })()
 
-    nodes.on("click", function() {
-        nodes.classed("focused-node", false);
-        d3.select(this).classed("focused-node", true);
+    nodes.on("click", function(d) {
+        // nodes.classed("focused-node", false);
+        // d3.select(this).classed("focused-node", true);
+        document.querySelectorAll(".focused-node").forEach(el => el.classList.remove("focused-node"));
+        document.querySelectorAll(`.node-${d.id}`).forEach(el => el.classList.add("focused-node"));
     });
 })
 </script>

--- a/graph_explorer/graph_explorer/templates/tree_view.html
+++ b/graph_explorer/graph_explorer/templates/tree_view.html
@@ -53,10 +53,6 @@
     color: #777;
     margin-left: 20px;
 }
-.selected-node {
-    border: 1px solid #ff9800 !important;
-    color: #ff9800 !important;
-}
 </style>
 
 <script>
@@ -104,9 +100,10 @@ document.addEventListener("DOMContentLoaded", function() {
 
         const nameSpan = document.createElement("span");
         nameSpan.textContent = node.name;
+        nameSpan.classList.add(`node-${node.id}`);
         nameSpan.addEventListener("click", function(event) {
-            document.querySelectorAll(".selected-node").forEach(el => el.classList.remove("selected-node"));
-            event.target.classList.add("selected-node")
+            document.querySelectorAll(".focused-node").forEach(el => el.classList.remove("focused-node"));
+            document.querySelectorAll(`.node-${node.id}`).forEach(el => el.classList.add("focused-node"));
         });
 
         if (hasExpandableChildren(node)) {

--- a/graph_explorer/graph_explorer/templates/tree_view.html
+++ b/graph_explorer/graph_explorer/templates/tree_view.html
@@ -53,6 +53,10 @@
     color: #777;
     margin-left: 20px;
 }
+.selected-node {
+    border: 1px solid #ff9800 !important;
+    color: #ff9800 !important;
+}
 </style>
 
 <script>
@@ -98,9 +102,12 @@ document.addEventListener("DOMContentLoaded", function() {
         const li = document.createElement("li");
         if (node.id) li.dataset.nodeId = node.id;
 
-        // name
         const nameSpan = document.createElement("span");
         nameSpan.textContent = node.name;
+        nameSpan.addEventListener("click", function(event) {
+            document.querySelectorAll(".selected-node").forEach(el => el.classList.remove("selected-node"));
+            event.target.classList.add("selected-node")
+        });
 
         if (hasExpandableChildren(node)) {
             nameSpan.classList.add("caret");

--- a/simple_visualizer/simple_visualizer/templates/simple_visualizer.html
+++ b/simple_visualizer/simple_visualizer/templates/simple_visualizer.html
@@ -102,7 +102,12 @@ function render() {
     node.append("text")
         .attr("text-anchor", "middle")
         .attr("dy", 4)
-        .text(d => d.id);
+        .text(d => d.id)
+
+    node.each(function(d) {
+        const g = d3.select(this);
+        g.classed("node-" + d.id, true);
+    })
 
     function ticked() {
         link.attr("x1", d => d.source.x)


### PR DESCRIPTION
Ticket number: #40

There is now an option to select the node and it will be selected in every view type. How? I added a class to every node in every view, that class is called node-{NODE_ID}. And then when someone clicks on a node, every previously focused stuff will be not focused and all classes sharing the same node id will be focused.