### PR TITLE
Value Type Conversion

### DIFF
--- a/data_source_xml/data_source_xml/parser.py
+++ b/data_source_xml/data_source_xml/parser.py
@@ -1,4 +1,5 @@
 from lxml import etree, html
+from datetime import datetime
 
 from graph_explorer_api.model.edge import Edge
 from graph_explorer_api.model.graph import Graph
@@ -47,16 +48,16 @@ class XmlParser:
         if len(xml_node.getchildren()) == 0:
             reference_value = xml_node.get(self.__reference_attribute)
             if reference_value is not None:
-                return reference_value
+                return self.__convert_value(reference_value)
             else:
-                return xml_node.tag, xml_node.text
+                return xml_node.tag, self.__convert_value(xml_node.text)
 
         data = {
             "name": xml_node.tag,
-            "text": xml_node.text
+            "text": self.__convert_value(xml_node.text)
         }
         if xml_node.attrib:
-            data.update(xml_node.attrib)
+            data.update({k: self.__convert_value(v) for k, v in xml_node.attrib.items()})
 
         new_node = Node(self.__node_count, data)
         self.__node_count += 1
@@ -80,7 +81,7 @@ class XmlParser:
 
             # this means that child_node is a leaf node, here it becomes an attribute
             elif child_node is not None:
-                data[child_node[0]] = child_node[1]
+                data[child_node[0]] = self.__convert_value(child_node[1])
 
             # this only happens if the child node had a reference child, meaning it should be an edge
             else:
@@ -96,7 +97,9 @@ class XmlParser:
                     reference_node = self.__find_reference_node(reference)
                     if reference_node is None:
                         continue
-                    self.__graph.edges.append(Edge(self.__edge_count, node, reference_node, data))
+                    self.__graph.edges.append(
+                        Edge(self.__edge_count, node, reference_node, {k: self.__convert_value(v) for k,v in data.items()})
+                    )
                     self.__edge_count += 1
                     break
 
@@ -115,3 +118,19 @@ class XmlParser:
         self.__xml_elements_to_graph_nodes = {}
         self.__graph = Graph()
         self.__node_count = 0
+
+    @staticmethod
+    def __convert_value(value):
+        if isinstance(value, str):
+            if value.isdigit():
+                return int(value)
+            try:
+                return float(value)
+            except ValueError:
+                pass
+            try:
+                return datetime.fromisoformat(value)
+            except ValueError:
+                pass
+            return value  # string
+        return value

--- a/data_source_xml/data_source_xml/test_files/test.xml
+++ b/data_source_xml/data_source_xml/test_files/test.xml
@@ -2,14 +2,15 @@
     <child_node>
         <leaf>Something</leaf>
         <friend>
-            <child_node reference="/node/child_node[2]"/>
+            <child_node reference="/node/child_node[2]" />
         </friend>
+        <birthday>2025-08-24 12:52:00</birthday>
     </child_node>
     <child_node>
         <leaf>Something else</leaf>
         <leaf2>End</leaf2>
         <friend description="good edge">
-            <child_node reference="/node/child_node[1]"/>
+            <child_node reference="/node/child_node[1]" />
         </friend>
     </child_node>
 </node>

--- a/graph_explorer/graph_explorer/views.py
+++ b/graph_explorer/graph_explorer/views.py
@@ -114,7 +114,11 @@ def cli_execute(request):
     if not active_ws:
         return JsonResponse({"error": "No active workspace"}, status=400)
 
-    result = execute_command(command, active_ws)
+    try:
+        result = execute_command(command, active_ws)
+    except Exception as e:
+        return JsonResponse({"error: ": str(e)}, status=400)
+    
     filter_error_msg = apply_filters(request, active_ws)
 
     active_ws.show_graph(plugin_service, tree_view_service)

--- a/platform/src/use_cases/cli/command_parser.py
+++ b/platform/src/use_cases/cli/command_parser.py
@@ -1,4 +1,5 @@
 import shlex
+from datetime import datetime
 
 def _parse_property(tokens, i, properties):
     if i + 1 >= len(tokens):
@@ -7,15 +8,14 @@ def _parse_property(tokens, i, properties):
     if "=" not in prop_token:
         raise ValueError(f"Invalid property format: {prop_token}")
     key, val = prop_token.split("=", 1)
-    properties[key] = val
+    properties[key] = _convert_value(val)
     return i + 2
 
 def _parse_arg(token, args):
     if "=" not in token:
         raise ValueError(f"Invalid argument format: {token}")
     key, val = token[2:].split("=", 1)
-    args[key] = val
-
+    args[key] = _convert_value(val)
 
 def parse_command(command_str: str):
     """
@@ -67,3 +67,19 @@ def parse_command(command_str: str):
         "args": args,
         "positional": positional
     }
+
+
+def _convert_value(value: str):
+    if isinstance(value, str):
+        if value.isdigit():
+            return int(value)
+        try:
+            return float(value)
+        except ValueError:
+            pass
+        try:
+            return datetime.fromisoformat(value)
+        except ValueError:
+            pass
+        return value
+    return value


### PR DESCRIPTION
Added a helper method for value conversion (int, float, datetime, str).  
The implementation is aligned with the one used in the JSON parser.

CLI examle:
`create node --id=999 --property today=2025-09-11`

Tested by returning type information in node creation commands:
    `return f"Node {node_id} created with {properties} (types: { {k: type(v).__name__ for k,v in properties.items()} })"`

Feel free to test it the same way.

This closes #58 
